### PR TITLE
Update api result error

### DIFF
--- a/src/Number26.php
+++ b/src/Number26.php
@@ -107,8 +107,8 @@ class Number26
                 }
             }
 
-            if (isset($apiResult->error) || isset($apiResult->error_description)) {
-                throw new Exception($apiResult->error . ': ' . $apiResult->error_description);
+            if (isset($apiResult->error)) {
+                throw new Exception($apiResult->error . ': ' . $apiResult->detail);
             }
             $this->setProperties($apiResult);
         } else {


### PR DESCRIPTION
It looks like the api changed and there is no `error_description` anymore. The apiResult eg returned:

```
{#339 ▼
  +"status": 429
  +"detail": "Too many log-in attempts. Please try again in 30 minutes."
  +"userMessage": {#340 ▼
    +"title": "Oops!"
    +"detail": "Too many log-in attempts. Please try again in 30 minutes."
  }
  +"error": "Oops!"
  +"title": "Oops!"
  +"message": "Too many log-in attempts. Please try again in 30 minutes."
}
```

So `$apiResult->error_description` was replaced with `$apiResult->detail`