### PR TITLE
Fix storing tokens / cookies: expiresTime

### DIFF
--- a/src/Number26.php
+++ b/src/Number26.php
@@ -221,7 +221,7 @@ class Number26
                 break;
             case self::STORE_COOKIES:
                 setcookie('n26Expire', $this->expiresTime, $this->expiresTime);
-                setcookie('n26Token', $this->accessToken, $expiresTime);
+                setcookie('n26Token', $this->accessToken, $this->expiresTime);
                 setcookie('n26Refresh', $this->refreshToken);
                 break;
         }


### PR DESCRIPTION
The `$expiresTime` variable in `setcookie('n26Token', $this->accessToken, $this->expiresTime);` does not exist.

Changed to `$this->expiresTime`